### PR TITLE
issue/11 – Introduce a utility method to retrieve list of tab slugs

### DIFF
--- a/affiliatewp-affiliate-area-tabs.php
+++ b/affiliatewp-affiliate-area-tabs.php
@@ -222,6 +222,9 @@ if ( ! class_exists( 'AffiliateWP_Affiliate_Area_Tabs' ) ) {
 
 			if ( $this->has_1_8() ) {
 				add_filter( 'affwp_affiliate_area_show_tab', array( $this, 'hide_existing_tabs' ), 10, 2 );
+				add_filter( 'affwp_affiliate_area_tabs', function( $tabs ) {
+					return array_merge( $tabs, $this->get_tab_slugs() );
+				} );
 			}
 
 		}
@@ -317,6 +320,21 @@ if ( ! class_exists( 'AffiliateWP_Affiliate_Area_Tabs' ) ) {
 			}
 
 			return $tabs;
+		}
+
+		/**
+		 * Retrieves tabs as a list of slugs.
+		 *
+		 * @since 1.1.1
+		 * @access public
+		 *
+		 * @return array List of tab slugs.
+		 */
+		public function get_tab_slugs() {
+			$tabs  = affiliate_wp()->settings->get( 'affiliate_area_tabs', array() );
+			$slugs = array_map( array( $this, 'make_slug' ), wp_list_pluck( $tabs, 'title' ) );
+
+			return $slugs;
 		}
 
 		/**

--- a/affiliatewp-affiliate-area-tabs.php
+++ b/affiliatewp-affiliate-area-tabs.php
@@ -313,7 +313,7 @@ if ( ! class_exists( 'AffiliateWP_Affiliate_Area_Tabs' ) ) {
 		 */
 		public function get_tabs() {
 
-			$tabs = affiliate_wp()->settings->get( 'affiliate_area_tabs' );
+			$tabs = affiliate_wp()->settings->get( 'affiliate_area_tabs', array() );
 
 			if ( ! empty( $tabs ) ) {
 				$tabs = array_values( $tabs );


### PR DESCRIPTION
Issue: #11 

Hooks into the new core `affwp_affiliate_area_tabs` filter to put affiliate area tabs in play for the active tab logic being adjusted in Core v1.8.1 and Affiliate Area Tabs v1.1.1.