### PR TITLE
Issue/55 - Switching languages does not also change tab title

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -166,7 +166,7 @@ class AffiliateWP_Affiliate_Area_Tabs_Admin {
 	public function admin_scripts() {
 
 		// Admin CSS file.
-		$screen = get_current_screen();
+		$screen = affwp_get_current_screen();
 
 		// Use minified libraries if SCRIPT_DEBUG is set to false.
 		$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
@@ -176,7 +176,7 @@ class AffiliateWP_Affiliate_Area_Tabs_Admin {
 		wp_register_script( 'aat-admin-scripts', AFFWP_AAT_PLUGIN_URL . 'assets/js/admin-scripts' . $suffix . '.js',  array(), AFFWP_AAT_VERSION, false );
 
 		// Enqueue scripts.
-		if ( $screen->id === 'affiliates_page_affiliate-wp-settings' && isset( $_GET['tab'] ) && $_GET['tab'] === 'affiliate_area_tabs' ) {
+		if ( $screen === 'affiliate-wp-settings' && isset( $_GET['tab'] ) && $_GET['tab'] === 'affiliate_area_tabs' ) {
 			wp_enqueue_style( 'aat-admin' );
 			wp_enqueue_script( 'aat-admin-scripts' );
 		}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -74,7 +74,7 @@ class AffiliateWP_Affiliate_Area_Tabs_Admin {
 	 * @return array $new_value
 	 */
 	public function pre_update_option( $new_value, $old_value ) {
-		
+
 		if ( isset( $new_value['affiliate_area_tabs'] ) ) {
 
 			// Loop through tabs.
@@ -89,6 +89,17 @@ class AffiliateWP_Affiliate_Area_Tabs_Admin {
 
 				if ( array_key_exists( $tab['slug'], $default_tabs ) ) {
 					$new_value['affiliate_area_tabs'][$key]['title'] = $default_tabs[$tab['slug']];
+				}
+
+				/**
+				 * Reset any add-on tab's title based on the add-on's text domain.
+				 * This ensures the tab title is correctly translated again on save 
+				 * if the site's language is changed.
+				 */
+				$add_on_tabs = affiliatewp_affiliate_area_tabs()->functions->add_on_tabs();
+				
+				if ( array_key_exists( $tab['slug'], $add_on_tabs ) ) {
+					$new_value['affiliate_area_tabs'][$key]['title'] = $add_on_tabs[$tab['slug']]['title'];
 				}
 
 				// Skip sanitization on any non-custom tab.

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -74,12 +74,23 @@ class AffiliateWP_Affiliate_Area_Tabs_Admin {
 	 * @return array $new_value
 	 */
 	public function pre_update_option( $new_value, $old_value ) {
-
+		
 		if ( isset( $new_value['affiliate_area_tabs'] ) ) {
 			
 			// Loop through tabs.
 			foreach ( $new_value['affiliate_area_tabs'] as $key => $tab ) {
 				
+				/**
+				 * Reset any default tab's title based on the affiliate-wp 
+				 * text domain. This ensures the tab title is correctly
+				 * translated again on save if the site's language is changed.
+				 */
+				$default_tabs = affiliatewp_affiliate_area_tabs()->functions->default_tabs();
+
+				if ( array_key_exists( $tab['slug'], $default_tabs ) ) {
+					$new_value['affiliate_area_tabs'][$key]['title'] = $default_tabs[$tab['slug']];
+				}
+
 				// Skip sanitization on any non-custom tab.
 				if ( 0 === $tab['id'] ) {
 					continue;
@@ -150,8 +161,8 @@ class AffiliateWP_Affiliate_Area_Tabs_Admin {
 				}
 
 			}
+
 		}
-		
 
 		return $new_value;
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -76,7 +76,7 @@ class AffiliateWP_Affiliate_Area_Tabs_Admin {
 	public function pre_update_option( $new_value, $old_value ) {
 		
 		if ( isset( $new_value['affiliate_area_tabs'] ) ) {
-			
+
 			// Loop through tabs.
 			foreach ( $new_value['affiliate_area_tabs'] as $key => $tab ) {
 				

--- a/includes/class-functions.php
+++ b/includes/class-functions.php
@@ -38,14 +38,14 @@ class AffiliateWP_Affiliate_Area_Tabs_Functions {
 	public function default_tabs() {
         
         $default_tabs = array(
-            'urls'      => __( 'Affiliate URLs', 'affiliatewp-affiliate-area-tabs' ),
-            'stats'     => __( 'Statistics', 'affiliatewp-affiliate-area-tabs' ),
-            'graphs'    => __( 'Graphs', 'affiliatewp-affiliate-area-tabs' ),
-            'referrals' => __( 'Referrals', 'affiliatewp-affiliate-area-tabs' ),
-            'payouts'   => __( 'Payouts', 'affiliatewp-affiliate-area-tabs' ),
-            'visits'    => __( 'Visits', 'affiliatewp-affiliate-area-tabs' ),
-            'creatives' => __( 'Creatives', 'affiliatewp-affiliate-area-tabs' ),
-            'settings'  => __( 'Settings', 'affiliatewp-affiliate-area-tabs' )
+            'urls'      => __( 'Affiliate URLs', 'affiliate-wp' ),
+            'stats'     => __( 'Statistics', 'affiliate-wp' ),
+            'graphs'    => __( 'Graphs', 'affiliate-wp' ),
+            'referrals' => __( 'Referrals', 'affiliate-wp' ),
+            'payouts'   => __( 'Payouts', 'affiliate-wp' ),
+            'visits'    => __( 'Visits', 'affiliate-wp' ),
+            'creatives' => __( 'Creatives', 'affiliate-wp' ),
+            'settings'  => __( 'Settings', 'affiliate-wp' )
         );
 
         return $default_tabs;

--- a/includes/class-functions.php
+++ b/includes/class-functions.php
@@ -36,7 +36,7 @@ class AffiliateWP_Affiliate_Area_Tabs_Functions {
 	 * @return array $default_tabs Array of default tabs.
 	 */
 	public function default_tabs() {
-        
+
         $default_tabs = array(
             'urls'      => __( 'Affiliate URLs', 'affiliate-wp' ),
             'stats'     => __( 'Statistics', 'affiliate-wp' ),
@@ -241,13 +241,16 @@ class AffiliateWP_Affiliate_Area_Tabs_Functions {
         $tabs = apply_filters( 'affwp_aat_add_on_tabs', 
             array(
                 'direct-links' => array(
-                    'notice' => sprintf( __( 'This tab has been added from the %s add-on. Only affiliates with direct link tracking enabled will see this tab in the Affiliate Area.', 'affiliatewp-affiliate-area-tabs' ), '<em>Direct Link Tracking</em>' )
+                    'notice' => sprintf( __( 'This tab has been added from the %s add-on. Only affiliates with direct link tracking enabled will see this tab in the Affiliate Area.', 'affiliatewp-affiliate-area-tabs' ), '<em>Direct Link Tracking</em>' ),
+                    'title'  => __( 'Direct Links', 'affiliatewp-direct-link-tracking' )
                 ),
                 'order-details' => array(
-                    'notice' => sprintf( __( 'This tab has been added from the %s add-on. Only affiliates with access to order details will see this tab in the Affiliate Area.', 'affiliatewp-affiliate-area-tabs' ), '<em>Order Details For Affiliates</em>' )
+                    'notice' => sprintf( __( 'This tab has been added from the %s add-on. Only affiliates with access to order details will see this tab in the Affiliate Area.', 'affiliatewp-affiliate-area-tabs' ), '<em>Order Details For Affiliates</em>' ),
+                    'title'  => __( 'Order Details', 'affiliatewp-order-details-for-affiliates' )
                 ),
                 'coupons' => array(
-                    'notice' => sprintf( __( 'This tab has been added from the %s add-on. Only affiliates with coupons assigned will see this tab in the Affiliate Area.', 'affiliatewp-affiliate-area-tabs' ), '<em>Show Affiliate Coupons</em>' )
+                    'notice' => sprintf( __( 'This tab has been added from the %s add-on. Only affiliates with coupons assigned will see this tab in the Affiliate Area.', 'affiliatewp-affiliate-area-tabs' ), '<em>Show Affiliate Coupons</em>' ),
+                    'title'  => __( 'Coupons', 'affiliatewp-show-affiliate-coupons' )
                 )
             )
         );


### PR DESCRIPTION
#55 

This also includes the changes from https://github.com/AffiliateWP/affiliatewp-affiliate-area-tabs/issues/53 since issue deals with switching languages.