### PR TITLE
Version 1.2.9 Release

### DIFF
--- a/affiliatewp-affiliate-area-tabs.php
+++ b/affiliatewp-affiliate-area-tabs.php
@@ -446,6 +446,25 @@ if ( ! class_exists( 'AffiliateWP_Affiliate_Area_Tabs' ) ) {
 		}
 
 		/**
+		 * Determines if the post content has blocks.
+		 *
+		 * @since 1.2.9
+		 *
+		 * @param string $post_content Post content.
+		 * @return bool True if the post content has blocks, otherwise false.
+		 */
+		public function has_blocks( $post_content ) {
+
+			$return = true;
+
+			if ( ! function_exists( 'has_blocks' ) || ! has_blocks( $post_content ) ) {
+				$return = false;
+			}
+
+			return $return;
+		}
+
+		/**
 		 * Redirect to affiliate login page if content is accessed.
 		 *
 		 * @since 1.0.1

--- a/affiliatewp-affiliate-area-tabs.php
+++ b/affiliatewp-affiliate-area-tabs.php
@@ -5,7 +5,7 @@
  * Description: Add and reorder tabs in the Affiliate Area
  * Author: Sandhills Development, LLC
  * Author URI: https://sandhillsdev.com
- * Version: 1.2.8
+ * Version: 1.2.9
  * Text Domain: affiliatewp-affiliate-area-tabs
  * Domain Path: languages
  *
@@ -48,7 +48,7 @@ if ( ! class_exists( 'AffiliateWP_Affiliate_Area_Tabs' ) ) {
 		 *
 		 * @since 1.0
 		 */
-		private $version = '1.2.8';
+		private $version = '1.2.9';
 
 		/**
 		 * The functions instance variable

--- a/affiliatewp-affiliate-area-tabs.php
+++ b/affiliatewp-affiliate-area-tabs.php
@@ -428,6 +428,24 @@ if ( ! class_exists( 'AffiliateWP_Affiliate_Area_Tabs' ) ) {
 		}
 
 		/**
+		 * Determine if the user is on version 2.6 of AffiliateWP or later.
+		 *
+		 * @since 1.2.9
+		 *
+		 * @return boolean
+		 */
+		public function has_2_6() {
+
+			$return = true;
+
+			if ( version_compare( AFFILIATEWP_VERSION, '2.6', '<' ) ) {
+				$return = false;
+			}
+
+			return $return;
+		}
+
+		/**
 		 * Redirect to affiliate login page if content is accessed.
 		 *
 		 * @since 1.0.1

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -227,8 +227,11 @@ class AffiliateWP_Affiliate_Area_Tabs_Admin {
 	 * @since 1.0.0
 	 */
 	public function tabs_list() {
-		
-		$tabs  = affiliatewp_affiliate_area_tabs()->functions->get_tabs();
+		$tabs = affiliatewp_affiliate_area_tabs()->functions->get_tabs();
+
+		// This ensure that drag & drop reordering work for the coupons tab in the admin.
+		$tabs = affiliatewp_affiliate_area_tabs()->affiliate_area_tabs( $tabs );
+
 		$count = count( $tabs );
 		$key   = 0;
 		?>

--- a/includes/class-functions.php
+++ b/includes/class-functions.php
@@ -298,8 +298,11 @@ class AffiliateWP_Affiliate_Area_Tabs_Functions {
 			wp_enqueue_style( 'jquery-ui-css' );
 		}
 
-		return do_shortcode( wpautop( $tab_content ) );
-
+		if ( affiliatewp_affiliate_area_tabs()->has_blocks( $tab_content ) ) {
+			return apply_filters( 'the_content', do_blocks( $tab_content ) );
+		} else {
+			return do_shortcode( wpautop( $tab_content ) );
+		}
 	}
 
 	/**

--- a/includes/class-functions.php
+++ b/includes/class-functions.php
@@ -44,8 +44,9 @@ class AffiliateWP_Affiliate_Area_Tabs_Functions {
 			'referrals' => __( 'Referrals', 'affiliate-wp' ),
 			'payouts'   => __( 'Payouts', 'affiliate-wp' ),
 			'visits'    => __( 'Visits', 'affiliate-wp' ),
+			'coupons'   => __( 'Coupons', 'affiliate-wp' ),
 			'creatives' => __( 'Creatives', 'affiliate-wp' ),
-			'settings'  => __( 'Settings', 'affiliate-wp' )
+			'settings'  => __( 'Settings', 'affiliate-wp' ),
 		);
 
 		return $default_tabs;
@@ -116,13 +117,15 @@ class AffiliateWP_Affiliate_Area_Tabs_Functions {
 	 *		'referrals' => 'Referrals',
 	 *		'payouts'   => 'Payouts',
 	 *		'visits'    => 'Visits',
+	 *		'coupons'   => 'Coupons',
 	 *		'creatives' => 'Creatives',
 	 *		'settings'  => 'Settings'
 	 *	)
 	 *
 	 * @access public
 	 * @since 1.1.6
-	 * @since 1.2 Use affwp_get_affiliate_area_tabs (since Affiliate 2.1.7), 
+	 * @since 1.2 Use affwp_get_affiliate_area_tabs (since Affiliate 2.1.7).
+	 * @since 1.2.9 Add coupons to tabs retrieved from affwp_get_affiliate_area_tabs() if it doesn't exists.
 	 * otherwise fallback
 	 * 
 	 * @return array $tabs The array of tabs to show
@@ -131,6 +134,11 @@ class AffiliateWP_Affiliate_Area_Tabs_Functions {
 		
 		if ( function_exists( 'affwp_get_affiliate_area_tabs' ) ) {
 			$tabs = affwp_get_affiliate_area_tabs();
+
+			if ( affiliatewp_affiliate_area_tabs()->has_2_6() && ! array_key_exists( 'coupons', $tabs ) ) {
+				$tabs['coupons'] = __( 'Coupons', 'affiliatewp-affiliate-area-tabs' );
+			}
+
 		} else {
 			
 			// Pre AffiliateWP v2.1.7.
@@ -325,6 +333,11 @@ class AffiliateWP_Affiliate_Area_Tabs_Functions {
 				)
 			)
 		);
+
+		// Remove the coupons tab as an add-on tab in AffiliateWP 2.6 and newer.
+		if ( affiliatewp_affiliate_area_tabs()->has_2_6() && array_key_exists( 'coupons', $tabs ) ) {
+			unset( $tabs['coupons'] );
+		}
 
 		return $tabs;
 

--- a/readme.txt
+++ b/readme.txt
@@ -56,6 +56,10 @@ OR you can just install it with WordPress by going to Plugins >> Add New >> and 
 
 == Changelog ==
 
+= 1.2.9 =
+* Fix: Unable to hide Coupons tab with AffiliateWP v2.6
+* Fix: Custom tabs not displaying dynamic blocks
+
 = 1.2.8 =
 * Fix: The "Lifetime Customers" tab title (added by the Lifetime Commissions add-on) was unable to be translated due to an incorrect textdomain
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: AffiliateWP, affiliate, affiliates, Pippin Williamson, Andrew Munro, morda
 Requires at least: 3.9
 Tested up to: 5.5
 Requires PHP: 5.3
-Stable tag: 1.2.8
+Stable tag: 1.2.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
https://github.com/AffiliateWP/affiliatewp-affiliate-area-tabs/milestone/18?closed=1

| Type | Ticket | Description |
| :----: | ------ | :----------- |
| Fix | #87  | Unable to hide Coupons tab with AffiliateWP v2.6 |
| Fix | #83  | Custom tabs not displaying dynamic blocks |